### PR TITLE
Adding return types to resolve PHP 8.0 deprecation notices. 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -21,7 +21,7 @@
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {

--- a/vendor/wpfluent/framework/src/WPFluent/Database/Orm/Model.php
+++ b/vendor/wpfluent/framework/src/WPFluent/Database/Orm/Model.php
@@ -2446,7 +2446,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -3444,7 +3444,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
      * @param  mixed  $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->$offset);
     }
@@ -3455,6 +3455,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
      * @param  mixed  $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange] // Suppresses deprecation message on 8.0 until min language level can be raised to 8.0
     public function offsetGet($offset)
     {
         return $this->$offset;
@@ -3467,7 +3468,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
      * @param  mixed  $value
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->$offset = $value;
     }
@@ -3478,7 +3479,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
      * @param  mixed  $offset
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->$offset);
     }

--- a/vendor/wpfluent/framework/src/WPFluent/Foundation/Container.php
+++ b/vendor/wpfluent/framework/src/WPFluent/Foundation/Container.php
@@ -1161,7 +1161,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $key
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return isset($this->bindings[$key]);
     }
@@ -1172,6 +1172,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $key
      * @return mixed
      */
+    #[\ReturnTypeWillChange] // Suppresses deprecation message on 8.0 until min language level can be raised to 8.0
     public function offsetGet($key)
     {
         return $this->make($key);
@@ -1184,7 +1185,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  mixed   $value
      * @return void
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         // If the value is not a Closure, we will make it one. This simply gives
         // more "drop-in" replacement functionality for the Pimple which this
@@ -1204,7 +1205,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $key
      * @return void
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->bindings[$key], $this->instances[$key], $this->resolved[$key]);
     }


### PR DESCRIPTION
When running on PHP 8.0+ a number of deprecation notices come up.  That's not a huge deal, but it's pretty annoying when using this tool for developing/debugging other plugins.  This PR addresses them, though also raises minimum PHP level to 7.1 (EOL in 2019). 

The issues are all within wpfluent/framework, which appears to now be either private or removed from Github, so I don't think I can contribute there.  These issues could also be resolved by updating that from the source. 